### PR TITLE
Add additional env parameters

### DIFF
--- a/backend/src/clients/__tests__/azureDevOpsClient.test.ts
+++ b/backend/src/clients/__tests__/azureDevOpsClient.test.ts
@@ -112,6 +112,8 @@ describe('AzureDevOpsClient', () => {
           templateParameters: {
               env: 'uat',
           },
+          state: 'completed',
+          result: 'succeeded',
           createdDate: '06/16/2012',
         }],
       };

--- a/backend/src/enums/environment.ts
+++ b/backend/src/enums/environment.ts
@@ -2,6 +2,11 @@
 export enum ENVIRONMENT {
   DEV = 'dev',
   INT = 'int',
-  PERF1 = 'perf1',
   UAT = 'uat',
+  PERF1 = 'perf1',
+  PERF2 = 'perf2',
+  PERF1_2 = 'perf1_2',
+  PROD1 = 'prod1',
+  PROD2 = 'prod2',
+  PROD1_2 = 'prod1_2',
 }

--- a/backend/src/services/__tests__/azureDevOpsService.test.ts
+++ b/backend/src/services/__tests__/azureDevOpsService.test.ts
@@ -135,6 +135,8 @@ const createMockPipelineRun = (id: number, name: string, createdDate: string, en
   id,
   name,
   createdDate,
+  state: 'completed',
+  result: 'succeeded',
   templateParameters: env ? { 
     env
   } : {},

--- a/backend/src/services/azureDevOpsService.ts
+++ b/backend/src/services/azureDevOpsService.ts
@@ -196,20 +196,17 @@ async function getMostRecentReleasePipelineRunByEnvironment(
 
   // Get the most recent run for the environment
   if (pipeline.folder === config.MANUAL_RELEASE_DIRECTORY) {
-    const perfEnvironments = [ENVIRONMENT.PERF1, ENVIRONMENT.PERF2];
-    const prodEnvironments = [ENVIRONMENT.PROD1, ENVIRONMENT.PROD2];
+    // PERF & PROD have pipelines that allow for deploying to both environments so we need to account for that
+    const pairedEnv: Partial<Record<ENVIRONMENT, ENVIRONMENT>> = {
+      [ENVIRONMENT.PERF1]: ENVIRONMENT.PERF1_2,
+      [ENVIRONMENT.PERF2]: ENVIRONMENT.PERF1_2,
+      [ENVIRONMENT.PROD1]: ENVIRONMENT.PROD1_2,
+      [ENVIRONMENT.PROD2]: ENVIRONMENT.PROD1_2,
+    };
 
-    // start with the target environment
-    const combinedEnvironments = [environment];
-
-    // if it's one of the perf environments, add PERF1_2
-    if (perfEnvironments.includes(environment)) {
-      combinedEnvironments.push(ENVIRONMENT.PERF1_2);
-    }
-
-    if (prodEnvironments.includes(environment)) {
-      combinedEnvironments.push(ENVIRONMENT.PROD1_2);
-    }
+    const combinedEnvironments = [environment, pairedEnv[environment]].filter(
+      (env): env is ENVIRONMENT => !!env,
+    );
 
     // pick the first run whose env is in that list
     mostRecentPipelineRun = sortedRuns.find((run) => {

--- a/backend/src/services/azureDevOpsService.ts
+++ b/backend/src/services/azureDevOpsService.ts
@@ -186,9 +186,9 @@ async function getMostRecentReleasePipelineRunByEnvironment(
 
   if (!allRuns || allRuns.length === 0) return null;
 
-  const sortedRuns = allRuns.sort(
-    (a, b) => new Date(b.createdDate).getTime() - new Date(a.createdDate).getTime(),
-  );
+  const sortedRuns = allRuns
+    .filter((run) => run.result === 'succeeded' && run.state === 'completed')
+    .sort((a, b) => new Date(b.createdDate).getTime() - new Date(a.createdDate).getTime());
 
   // Get the most recent run for the environment
   if (pipeline.folder === config.MANUAL_RELEASE_DIRECTORY) {

--- a/backend/src/types/AzureDevOpsTypes.ts
+++ b/backend/src/types/AzureDevOpsTypes.ts
@@ -14,6 +14,8 @@ export type PipelineRunResponse = {
     templateParameters: {
       env?: string;
     };
+    state: string;
+    result: string;
     createdDate: string;
   }[];
 };

--- a/frontend/src/components/Dropdown/Dropdown.test.tsx
+++ b/frontend/src/components/Dropdown/Dropdown.test.tsx
@@ -77,6 +77,15 @@ describe('Dropdown component', () => {
         expect(optionText).toHaveTextContent(mockOptions[index]);
       });
     });
+
+    it('scrolls to the selected option when opened', () => {
+      // Render with a non-first selected option to ensure scrolling is needed
+      renderDropdown(['Option 1', 'Option 2', 'Option 3'], 'Option 2');
+      // Open the dropdown to trigger scrollIntoView
+      openDropdown();
+      // Expect scrollIntoView called with center-alignment
+      expect(Element.prototype.scrollIntoView).toHaveBeenCalledWith({ block: 'center' });
+    });
   });
 
   describe('interaction behavior', () => {

--- a/frontend/src/components/Dropdown/Dropdown.tsx
+++ b/frontend/src/components/Dropdown/Dropdown.tsx
@@ -37,6 +37,13 @@ const Dropdown: React.FC<DropdownProps> = ({
     };
   }, []);
 
+  // Scroll selected option into view when dropdown opens
+  useEffect(() => {
+    if (isDropdownOpen && selectedOptionRef.current) {
+      selectedOptionRef.current.scrollIntoView({ block: 'center' });
+    }
+  }, [isDropdownOpen]);
+
   const handleOptionChange = (option: string) => {
     onOptionChange(option);
     setIsDropdownOpen(false);

--- a/frontend/src/components/ReleasedVersions/ReleasedVersions.test.tsx
+++ b/frontend/src/components/ReleasedVersions/ReleasedVersions.test.tsx
@@ -3,6 +3,18 @@ import { beforeEach, describe, expect, it, vi } from 'vitest';
 
 import ReleasedVersions from './ReleasedVersions';
 
+const ENVIRONMENT_OPTIONS = [
+  'DEV',
+  'INT',
+  'UAT',
+  'PERF1',
+  'PERF2',
+  'PERF1_2',
+  'PROD1',
+  'PROD2',
+  'PROD1_2',
+];
+
 const mocks = vi.hoisted(() => {
   return {
     mockReleasedVersionsList: vi.fn(() => (
@@ -70,7 +82,7 @@ describe('ReleasedVersions component', () => {
 
       expect(mocks.mockDropdown).toHaveBeenCalledWith(
         {
-          options: ['DEV', 'INT', 'UAT', 'PERF1'],
+          options: ENVIRONMENT_OPTIONS,
           selectedOption: 'UAT',
           storageKey: 'selectedEnvironment',
           onOptionChange: expect.any(Function),
@@ -95,7 +107,7 @@ describe('ReleasedVersions component', () => {
 
       expect(mocks.mockDropdown).toHaveBeenCalledWith(
         {
-          options: ['DEV', 'INT', 'UAT', 'PERF1'],
+          options: ENVIRONMENT_OPTIONS,
           selectedOption: savedEnv,
           storageKey: 'selectedEnvironment',
           onOptionChange: expect.any(Function),
@@ -118,7 +130,7 @@ describe('ReleasedVersions component', () => {
 
       expect(mocks.mockDropdown).toHaveBeenCalledWith(
         {
-          options: ['DEV', 'INT', 'UAT', 'PERF1'],
+          options: ENVIRONMENT_OPTIONS,
           selectedOption: 'UAT',
           storageKey: 'selectedEnvironment',
           onOptionChange: expect.any(Function),

--- a/frontend/src/components/ReleasedVersions/ReleasedVersions.test.tsx
+++ b/frontend/src/components/ReleasedVersions/ReleasedVersions.test.tsx
@@ -3,17 +3,7 @@ import { beforeEach, describe, expect, it, vi } from 'vitest';
 
 import ReleasedVersions from './ReleasedVersions';
 
-const ENVIRONMENT_OPTIONS = [
-  'DEV',
-  'INT',
-  'UAT',
-  'PERF1',
-  'PERF2',
-  'PERF1_2',
-  'PROD1',
-  'PROD2',
-  'PROD1_2',
-];
+const ENVIRONMENT_OPTIONS = ['DEV', 'INT', 'UAT', 'PERF1', 'PERF2', 'PROD1', 'PROD2'];
 
 const mocks = vi.hoisted(() => {
   return {

--- a/frontend/src/components/ReleasedVersions/ReleasedVersions.tsx
+++ b/frontend/src/components/ReleasedVersions/ReleasedVersions.tsx
@@ -7,17 +7,7 @@ import styles from './ReleasedVersions.module.css';
 const LOCAL_STORAGE_KEY = 'selectedEnvironment';
 
 const ReleasedVersions: React.FC = () => {
-  const environments = [
-    'DEV',
-    'INT',
-    'UAT',
-    'PERF1',
-    'PERF2',
-    'PERF1_2',
-    'PROD1',
-    'PROD2',
-    'PROD1_2',
-  ];
+  const environments = ['DEV', 'INT', 'UAT', 'PERF1', 'PERF2', 'PROD1', 'PROD2'];
 
   const [selectedEnvironment, setSelectedEnvironment] = useState(() => {
     const savedEnv = localStorage.getItem(LOCAL_STORAGE_KEY);

--- a/frontend/src/components/ReleasedVersions/ReleasedVersions.tsx
+++ b/frontend/src/components/ReleasedVersions/ReleasedVersions.tsx
@@ -7,7 +7,17 @@ import styles from './ReleasedVersions.module.css';
 const LOCAL_STORAGE_KEY = 'selectedEnvironment';
 
 const ReleasedVersions: React.FC = () => {
-  const environments = ['DEV', 'INT', 'UAT', 'PERF1'];
+  const environments = [
+    'DEV',
+    'INT',
+    'UAT',
+    'PERF1',
+    'PERF2',
+    'PERF1_2',
+    'PROD1',
+    'PROD2',
+    'PROD1_2',
+  ];
 
   const [selectedEnvironment, setSelectedEnvironment] = useState(() => {
     const savedEnv = localStorage.getItem(LOCAL_STORAGE_KEY);


### PR DESCRIPTION
This pull request introduces changes to support additional environments in the backend and frontend, enhances the filtering logic for pipeline runs, and improves the user experience in the dropdown component. Below is a summary of the most important changes:

### Backend Changes

#### Environment Support:
* Added new environments (`PERF2`, `PERF1_2`, `PROD1`, `PROD2`, `PROD1_2`) to the `ENVIRONMENT` enum in `backend/src/enums/environment.ts`.

#### Pipeline Filtering:
* Updated the `PipelineRunResponse` type to include `state` and `result` fields in `backend/src/types/AzureDevOpsTypes.ts`.
* Enhanced the `getMostRecentReleasePipelineRunByEnvironment` function to filter pipeline runs by `state` and `result` and to account for paired environments (e.g., `PERF1` and `PERF1_2`) in `backend/src/services/azureDevOpsService.ts`.

#### Test Updates:
* Updated mock data and test cases to include the new `state` and `result` fields in `azureDevOpsService` and `azureDevOpsClient` tests. [[1]](diffhunk://#diff-6146d05ebd38f2a22f03ed07ff0ec5e087cd057924c25b48c2ebcf3754f920d4R115-R116) [[2]](diffhunk://#diff-80f5405a5b9421bddf508072338885e2ed77eb89631d82ee1d652b95597b30eaR138-R139)

### Frontend Changes

#### Dropdown Component:
* Added functionality to scroll the selected option into view when the dropdown opens in `frontend/src/components/Dropdown/Dropdown.tsx`.
* Added a corresponding test to verify the scroll behavior in `frontend/src/components/Dropdown/Dropdown.test.tsx`.

#### Released Versions Component:
* Extended the list of environments in the `ReleasedVersions` component to include the new environments in `frontend/src/components/ReleasedVersions/ReleasedVersions.tsx`.
* Updated tests to use a centralized `ENVIRONMENT_OPTIONS` array for consistency in `frontend/src/components/ReleasedVersions/ReleasedVersions.test.tsx`. [[1]](diffhunk://#diff-8cfb16f82ece4b6c64c4ba4b02b393f1251ae64ec39c495cb4f88ca5e3277c86R6-R7) [[2]](diffhunk://#diff-8cfb16f82ece4b6c64c4ba4b02b393f1251ae64ec39c495cb4f88ca5e3277c86L73-R75) [[3]](diffhunk://#diff-8cfb16f82ece4b6c64c4ba4b02b393f1251ae64ec39c495cb4f88ca5e3277c86L98-R100) [[4]](diffhunk://#diff-8cfb16f82ece4b6c64c4ba4b02b393f1251ae64ec39c495cb4f88ca5e3277c86L121-R123)